### PR TITLE
Convert static site into a local-first Kanban web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,19 @@
-# CodexTest
-Testing OpenAI Codex
+# Kanban Board Web App
 
-This repository contains a simple responsive web application with three pages:
+A lightweight, local-first kanban board you can use for personal workflow tracking.
 
-- **index.html** – the home page
-- **about.html** – information about the site
-- **contact.html** – a contact form that displays a thank-you message
+## Features
 
-To view the site, open `index.html` in a web browser.
+- Create tasks with title, details, and priority
+- Move tasks between **To Do**, **Doing**, and **Done**
+- Use drag-and-drop or move buttons
+- Delete tasks you no longer need
+- Auto-saves board state to browser `localStorage`
+
+## Run
+
+Open `index.html` directly in your browser.
+
+## Notes
+
+All data is stored in your browser only.

--- a/index.html
+++ b/index.html
@@ -3,29 +3,56 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Home - Codex WebApp</title>
+    <title>Workflow Kanban Board</title>
     <link rel="stylesheet" href="style.css">
 </head>
 <body>
-    <header>
-        <h1>Welcome to Codex WebApp</h1>
-        <nav>
-            <ul>
-                <li><a href="index.html">Home</a></li>
-                <li><a href="about.html">About</a></li>
-                <li><a href="contact.html">Contact</a></li>
-            </ul>
-        </nav>
+    <header class="app-header">
+        <h1>My Kanban</h1>
+        <form id="add-task-form" class="add-task-form">
+            <input id="task-title" name="title" type="text" placeholder="New task title" maxlength="120" required>
+            <textarea id="task-desc" name="description" placeholder="Optional details" rows="2" maxlength="400"></textarea>
+            <select id="task-priority" name="priority">
+                <option value="low">Low priority</option>
+                <option value="medium" selected>Medium priority</option>
+                <option value="high">High priority</option>
+            </select>
+            <button type="submit">Add Task</button>
+        </form>
     </header>
+
     <main>
-        <section class="hero">
-            <h2>Responsive Web Application</h2>
-            <p>This is the home page content.</p>
+        <section class="board" id="board">
+            <div class="column" data-column="todo">
+                <h2>To Do</h2>
+                <div class="task-list" id="todo-list"></div>
+            </div>
+            <div class="column" data-column="doing">
+                <h2>Doing</h2>
+                <div class="task-list" id="doing-list"></div>
+            </div>
+            <div class="column" data-column="done">
+                <h2>Done</h2>
+                <div class="task-list" id="done-list"></div>
+            </div>
         </section>
     </main>
-    <footer>
-        <p>&copy; 2025 Codex WebApp</p>
-    </footer>
+
+    <template id="task-template">
+        <article class="task" draggable="true">
+            <header>
+                <h3 class="task-title"></h3>
+                <span class="priority"></span>
+            </header>
+            <p class="task-desc"></p>
+            <footer class="task-actions">
+                <button data-action="left" title="Move left">←</button>
+                <button data-action="right" title="Move right">→</button>
+                <button data-action="delete" title="Delete task">Delete</button>
+            </footer>
+        </article>
+    </template>
+
     <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,11 +1,151 @@
+const STORAGE_KEY = 'kanban-board-v1';
+const COLUMN_ORDER = ['todo', 'doing', 'done'];
+
+const boardState = loadState();
+
 document.addEventListener('DOMContentLoaded', () => {
-    const form = document.getElementById('contact-form');
-    if (form) {
-        form.addEventListener('submit', function (e) {
-            e.preventDefault();
-            const status = document.getElementById('form-status');
-            status.textContent = 'Thank you for your message!';
-            form.reset();
-        });
-    }
+    const form = document.getElementById('add-task-form');
+    form.addEventListener('submit', onAddTask);
+
+    setupDragAndDrop();
+    renderBoard();
 });
+
+function loadState() {
+    const raw = localStorage.getItem(STORAGE_KEY);
+    if (!raw) return { todo: [], doing: [], done: [] };
+
+    try {
+        const parsed = JSON.parse(raw);
+        return {
+            todo: parsed.todo ?? [],
+            doing: parsed.doing ?? [],
+            done: parsed.done ?? []
+        };
+    } catch {
+        return { todo: [], doing: [], done: [] };
+    }
+}
+
+function saveState() {
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(boardState));
+}
+
+function onAddTask(event) {
+    event.preventDefault();
+    const titleEl = document.getElementById('task-title');
+    const descEl = document.getElementById('task-desc');
+    const priorityEl = document.getElementById('task-priority');
+
+    const task = {
+        id: crypto.randomUUID(),
+        title: titleEl.value.trim(),
+        description: descEl.value.trim(),
+        priority: priorityEl.value
+    };
+
+    if (!task.title) return;
+
+    boardState.todo.unshift(task);
+    saveState();
+    renderBoard();
+    event.target.reset();
+    titleEl.focus();
+}
+
+function renderBoard() {
+    COLUMN_ORDER.forEach((column) => {
+        const list = document.getElementById(`${column}-list`);
+        list.innerHTML = '';
+
+        boardState[column].forEach((task) => {
+            list.appendChild(renderTask(task, column));
+        });
+    });
+}
+
+function renderTask(task, column) {
+    const template = document.getElementById('task-template');
+    const node = template.content.firstElementChild.cloneNode(true);
+
+    node.dataset.id = task.id;
+    node.dataset.column = column;
+    node.querySelector('.task-title').textContent = task.title;
+    node.querySelector('.task-desc').textContent = task.description || 'No description';
+
+    const priorityNode = node.querySelector('.priority');
+    priorityNode.textContent = task.priority;
+    priorityNode.classList.add(task.priority);
+
+    node.querySelectorAll('button').forEach((btn) => {
+        btn.addEventListener('click', () => handleTaskAction(task.id, column, btn.dataset.action));
+    });
+
+    node.addEventListener('dragstart', onDragStart);
+    node.addEventListener('dragend', onDragEnd);
+
+    return node;
+}
+
+function handleTaskAction(taskId, column, action) {
+    if (action === 'delete') {
+        boardState[column] = boardState[column].filter((task) => task.id !== taskId);
+    } else {
+        const currentIndex = COLUMN_ORDER.indexOf(column);
+        const targetIndex = action === 'left' ? currentIndex - 1 : currentIndex + 1;
+        if (targetIndex < 0 || targetIndex >= COLUMN_ORDER.length) return;
+
+        const taskIndex = boardState[column].findIndex((task) => task.id === taskId);
+        if (taskIndex < 0) return;
+
+        const [task] = boardState[column].splice(taskIndex, 1);
+        boardState[COLUMN_ORDER[targetIndex]].unshift(task);
+    }
+
+    saveState();
+    renderBoard();
+}
+
+function setupDragAndDrop() {
+    document.querySelectorAll('.column').forEach((columnEl) => {
+        columnEl.addEventListener('dragover', (event) => {
+            event.preventDefault();
+            columnEl.classList.add('drag-over');
+        });
+
+        columnEl.addEventListener('dragleave', () => columnEl.classList.remove('drag-over'));
+
+        columnEl.addEventListener('drop', (event) => {
+            event.preventDefault();
+            columnEl.classList.remove('drag-over');
+
+            const data = JSON.parse(event.dataTransfer.getData('text/plain'));
+            if (!data?.taskId || !data?.fromColumn) return;
+            moveTask(data.taskId, data.fromColumn, columnEl.dataset.column);
+        });
+    });
+}
+
+function moveTask(taskId, fromColumn, toColumn) {
+    if (fromColumn === toColumn) return;
+
+    const index = boardState[fromColumn].findIndex((task) => task.id === taskId);
+    if (index < 0) return;
+
+    const [task] = boardState[fromColumn].splice(index, 1);
+    boardState[toColumn].unshift(task);
+    saveState();
+    renderBoard();
+}
+
+function onDragStart(event) {
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', JSON.stringify({
+        taskId: event.currentTarget.dataset.id,
+        fromColumn: event.currentTarget.dataset.column
+    }));
+}
+
+function onDragEnd() {
+    document.querySelectorAll('.column').forEach((col) => col.classList.remove('drag-over'));
+}

--- a/style.css
+++ b/style.css
@@ -1,56 +1,140 @@
+:root {
+    --bg: #f5f7fb;
+    --card: #ffffff;
+    --text: #1e293b;
+    --muted: #64748b;
+    --border: #dbe4f1;
+    --primary: #2563eb;
+    --todo: #eef2ff;
+    --doing: #fef9c3;
+    --done: #dcfce7;
+}
+
+* { box-sizing: border-box; }
+
 body {
     margin: 0;
-    font-family: Arial, sans-serif;
-    line-height: 1.6;
+    font-family: Inter, system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif;
+    color: var(--text);
+    background: var(--bg);
 }
 
-header {
-    background: #333;
-    color: #fff;
-    padding: 1rem 0;
-}
-
-header h1 {
-    margin: 0;
-    text-align: center;
-}
-
-nav ul {
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    display: flex;
-    justify-content: center;
-}
-
-nav li {
-    margin: 0 1rem;
-}
-
-nav a {
-    color: #fff;
-    text-decoration: none;
-}
-
-main {
+.app-header {
     padding: 1rem;
+    background: var(--card);
+    border-bottom: 1px solid var(--border);
+    position: sticky;
+    top: 0;
+    z-index: 10;
 }
 
-footer {
-    text-align: center;
-    padding: 1rem 0;
-    background: #f4f4f4;
-    margin-top: 2rem;
+h1 { margin: 0 0 0.75rem; }
+
+.add-task-form {
+    display: grid;
+    gap: 0.5rem;
+    grid-template-columns: 1fr;
 }
 
-@media (min-width: 600px) {
-    header,
-    footer {
-        padding: 1.5rem 0;
+input, textarea, select, button {
+    font: inherit;
+    padding: 0.6rem;
+    border-radius: 0.45rem;
+    border: 1px solid var(--border);
+}
+
+button {
+    cursor: pointer;
+    background: var(--primary);
+    color: white;
+    border: none;
+}
+
+main { padding: 1rem; }
+
+.board {
+    display: grid;
+    grid-template-columns: repeat(1, minmax(0, 1fr));
+    gap: 1rem;
+}
+
+.column {
+    background: var(--card);
+    border: 1px solid var(--border);
+    border-radius: 0.75rem;
+    padding: 0.75rem;
+    min-height: 50vh;
+}
+
+.column[data-column="todo"] { background: var(--todo); }
+.column[data-column="doing"] { background: var(--doing); }
+.column[data-column="done"] { background: var(--done); }
+
+.task-list {
+    display: grid;
+    gap: 0.7rem;
+    min-height: 40px;
+}
+
+.task {
+    background: white;
+    border: 1px solid var(--border);
+    border-radius: 0.6rem;
+    padding: 0.65rem;
+}
+
+.task header {
+    display: flex;
+    justify-content: space-between;
+    gap: 0.5rem;
+    align-items: center;
+}
+
+.task-title {
+    margin: 0;
+    font-size: 1rem;
+}
+
+.priority {
+    font-size: 0.75rem;
+    padding: 0.2rem 0.45rem;
+    border-radius: 999px;
+    text-transform: uppercase;
+    color: white;
+}
+
+.priority.low { background: #16a34a; }
+.priority.medium { background: #d97706; }
+.priority.high { background: #dc2626; }
+
+.task-desc {
+    margin: 0.5rem 0;
+    color: var(--muted);
+    white-space: pre-wrap;
+}
+
+.task-actions {
+    display: flex;
+    gap: 0.4rem;
+}
+
+.task-actions button:last-child {
+    margin-left: auto;
+    background: #ef4444;
+}
+
+.column.drag-over {
+    outline: 2px dashed #1d4ed8;
+    outline-offset: -4px;
+}
+
+@media (min-width: 900px) {
+    .add-task-form {
+        grid-template-columns: 2fr 2fr 1fr auto;
+        align-items: start;
     }
 
-    nav ul {
-        justify-content: flex-start;
-        margin-left: 1rem;
+    .board {
+        grid-template-columns: repeat(3, minmax(0, 1fr));
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the repository's placeholder multi-page site with a practical, dependency-free Kanban board for personal workflow tracking.
- Provide an easy-to-use, local-first app that persists tasks in the browser and supports common Kanban interactions like drag-and-drop and quick moves.

### Description
- Reworked `index.html` into a single-page Kanban interface with a task creation form (title, description, priority), three columns (`todo`, `doing`, `done`), and a reusable task template with move/delete controls.
- Replaced the previous script with `script.js` that implements board state loading/saving to `localStorage`, task creation, rendering, move-left/move-right actions, drag-and-drop across columns, and task deletion using `crypto.randomUUID()` for IDs.
- Updated `style.css` to a responsive Kanban layout with color-coded columns, priority badges, task-card styling, and a visual drag-over affordance.
- Updated `README.md` to document features, local-only persistence, and how to run the app by opening `index.html` in a browser.

### Testing
- Ran `node --check script.js` to validate the JavaScript syntax and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a023a525c04832fb41034a60ea570e0)