### PR TITLE
Make column sort dropdown an icon on mobile, aligned next to task count

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,4 @@
-import { ArrowRightLeft, CalendarDays, Check, ChevronDown, Menu, Pencil, Plus, Trash2, X } from "lucide-react";
+import { ArrowRightLeft, CalendarDays, Check, ChevronDown, Menu, Pencil, Plus, SlidersHorizontal, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Button } from "./components/ui/button";
 import {
@@ -948,25 +948,28 @@ export function App() {
                 <div className="column-title-row">
                   <h2>{column.title}</h2>
                   <span>{board[column.id].length}</span>
+                  <DropdownMenu>
+                    <DropdownMenuTrigger asChild>
+                      <Button className="sort-trigger" variant="noShadow" type="button" aria-label="Sort tasks">
+                        <span className="sort-trigger-label">{sortMode === "dateAdded" ? "Date added" : "Priority"}</span>
+                        <span className="sort-trigger-icon" aria-hidden="true">
+                          <SlidersHorizontal size={16} strokeWidth={3} />
+                        </span>
+                        <ChevronDown className="sort-trigger-caret" size={16} strokeWidth={3} />
+                      </Button>
+                    </DropdownMenuTrigger>
+                    <DropdownMenuContent className="sort-menu" align="end">
+                      <DropdownMenuLabel>Sort by</DropdownMenuLabel>
+                      <DropdownMenuSeparator />
+                      <DropdownMenuItem onSelect={() => setSorts((current) => ({ ...current, [column.id]: "dateAdded" }))}>
+                        Date added
+                      </DropdownMenuItem>
+                      <DropdownMenuItem onSelect={() => setSorts((current) => ({ ...current, [column.id]: "priority" }))}>
+                        Priority
+                      </DropdownMenuItem>
+                    </DropdownMenuContent>
+                  </DropdownMenu>
                 </div>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button className="sort-trigger" variant="noShadow" type="button">
-                      <span>{sortMode === "dateAdded" ? "Date added" : "Priority"}</span>
-                      <ChevronDown size={16} strokeWidth={3} />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent className="sort-menu" align="end">
-                    <DropdownMenuLabel>Sort by</DropdownMenuLabel>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem onSelect={() => setSorts((current) => ({ ...current, [column.id]: "dateAdded" }))}>
-                      Date added
-                    </DropdownMenuItem>
-                    <DropdownMenuItem onSelect={() => setSorts((current) => ({ ...current, [column.id]: "priority" }))}>
-                      Priority
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
               </header>
               <div className="task-list">
                 {sortTasks(board[column.id], sortMode).map((task) => {

--- a/src/styles.css
+++ b/src/styles.css
@@ -688,6 +688,10 @@ h1 {
   white-space: nowrap;
 }
 
+.sort-trigger-icon {
+  display: none;
+}
+
 .sort-trigger:hover {
   background: var(--muted);
 }
@@ -1014,17 +1018,29 @@ h1 {
   }
 
   .column-header {
-    align-items: stretch;
-    flex-direction: column;
+    align-items: flex-start;
   }
 
   .column-title-row {
-    justify-content: space-between;
+    justify-content: flex-start;
     width: 100%;
   }
 
   .sort-trigger {
-    width: 100%;
+    min-width: 38px;
+    width: 38px;
+    padding: 0;
+    margin-left: auto;
+    justify-content: center;
+  }
+
+  .sort-trigger-label,
+  .sort-trigger-caret {
+    display: none;
+  }
+
+  .sort-trigger-icon {
+    display: inline-flex;
   }
 }
 


### PR DESCRIPTION
### Motivation
- Reduce clutter in mobile column headers by replacing the text-based sort/filter trigger with a compact icon button placed next to the task count.
- Preserve desktop behavior and labels while providing an icon-only affordance on small viewports for better space usage.

### Description
- Imported the `SlidersHorizontal` icon and updated the column header markup so the `DropdownMenu` trigger lives inside the title/count row next to the task count in `src/App.tsx`.
- Changed the sort trigger button to include distinct label, icon, and caret elements (`.sort-trigger-label`, `.sort-trigger-icon`, `.sort-trigger-caret`) so presentation can switch responsively.
- Added CSS in `src/styles.css` to keep the existing text-based control on desktop and collapse the trigger to a right-aligned, icon-only 38×38 button on mobile by hiding the label and caret and showing the sliders icon.

### Testing
- Ran `npm run build` and the production build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a39acc64832fa641f64908c9b1be)