### PR TITLE
Adjust empty-state desktop scaling for iPad Air landscape

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -286,6 +286,8 @@ export function App() {
   );
   const activeBoard = workspace.boards.find((board) => board.id === workspace.activeBoardId) ?? workspace.boards[0];
   const board = activeBoard.columns;
+  const totalTasks = columns.reduce((count, column) => count + board[column.id].length, 0);
+  const isEmptyBoard = totalTasks === 0;
 
   useEffect(() => {
     localStorage.setItem(WORKSPACE_STORAGE_KEY, JSON.stringify(workspace));
@@ -561,7 +563,7 @@ export function App() {
   }
 
   return (
-    <main className="app-shell">
+    <main className={cn("app-shell", isEmptyBoard && "empty-state-view")}>
       <section className="app-header">
         <div className="brand-block" ref={brandBlockRef}>
           <h1 className="app-title" ref={appTitleRef}>

--- a/src/styles.css
+++ b/src/styles.css
@@ -908,6 +908,15 @@ h1 {
   }
 }
 
+@media (min-width: 900px) and (max-width: 1180px) and (max-height: 900px) {
+  .app-shell.empty-state-view {
+    width: min(1280px, calc(100% - 20px));
+    padding-top: 16px;
+    transform: scale(0.92);
+    transform-origin: top center;
+  }
+}
+
 @media (max-width: 640px) {
   .app-shell {
     width: min(100% - 20px, 1280px);


### PR DESCRIPTION
### Motivation
- Ensure the app's empty-state layout fits comfortably in a tablet landscape viewport (e.g. iPad Air) by slightly scaling and tightening the desktop shell when there are no tasks.

### Description
- Detect empty board state by computing `totalTasks` and `isEmptyBoard` in `src/App.tsx` and apply an `empty-state-view` class to the main shell when empty.
- Update the main wrapper to `className={cn("app-shell", isEmptyBoard && "empty-state-view")}` in `src/App.tsx`.
- Add a tablet-landscape media query in `src/styles.css` (`@media (min-width: 900px) and (max-width: 1180px) and (max-height: 900px)`) that scales the `.app-shell.empty-state-view` to `scale(0.92)` and tightens padding so the empty-state fits in a landscape tablet viewport.

### Testing
- Ran the production build with `npm run build` (TypeScript compile + `vite build`) and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a03a82736b4832fb7706f0cc3ccf13a)